### PR TITLE
Fix RectSelector coordinate casting bug

### DIFF
--- a/samples/python/common.py
+++ b/samples/python/common.py
@@ -170,7 +170,7 @@ class RectSelector:
         self.drag_start = None
         self.drag_rect = None
     def onmouse(self, event, x, y, flags, param):
-        x, y = np.int16([x, y]) # BUG
+        x, y = int(x), int(y)
         if event == cv.EVENT_LBUTTONDOWN:
             self.drag_start = (x, y)
             return


### PR DESCRIPTION
## Summary
- fix RectSelector coordinate casting to avoid overflow

## Testing
- `python3 -m py_compile samples/python/common.py`
- `python3 -m pytest -k "common" -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683fa5d13e588331bd52bb5977cc058d